### PR TITLE
Refactor GitHub Actions workflow for Python distribution publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
 on:
   release:
@@ -12,37 +12,101 @@ on:
         type: boolean
 
 jobs:
-  deploy:
+  build:
+    name: Build distribution 📦
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
       with:
-        python-version: '3.10'
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build twine
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
 
-    - name: Build
-      run: |
-        python -m build
-        twine check dist/*
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/github-project-manager
 
-    - name: Publish to TestPyPI
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  upload-to-release:
+    name: Upload artifacts to GitHub Release
+    if: github.event_name == 'release'
+    needs:
+    - build
+    - publish-to-testpypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Upload artifacts to GitHub Release
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release upload
+        "${{ github.event.release.tag_name }}" dist/**
+        --repo "$GITHUB_REPOSITORY"
 
-    - name: Publish to PyPI
-      if: github.event.inputs.publish_to_pypi == 'true'
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        twine upload dist/*
+  publish-to-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_pypi == 'true'
+    needs:
+    - build
+    - publish-to-testpypi
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/github-project-manager
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This commit refines the GitHub Actions workflow by renaming jobs for clarity, updating action versions, and enhancing the build and publish processes for both TestPyPI and PyPI. The build job now includes steps for installing dependencies and building the distribution, while the publish jobs are structured to ensure proper artifact handling and permissions for trusted publishing. Additionally, the workflow now supports uploading artifacts to GitHub Releases.